### PR TITLE
change deprecated asset to fromAsset method

### DIFF
--- a/lib/table-viewer.ts
+++ b/lib/table-viewer.ts
@@ -36,7 +36,7 @@ export class TableViewer extends cdk.Construct {
     super(parent, id);
 
     const handler = new lambda.Function(this, 'Rendered', {
-      code: lambda.Code.asset(path.join(__dirname, 'lambda')),
+      code: lambda.Code.fromAsset(path.join(__dirname, 'lambda')),
       runtime: lambda.Runtime.NODEJS_12_X,
       handler: 'index.handler',
       environment: {


### PR DESCRIPTION
asset property of lambda.Code.asset method has been deprecated.

This PR uses the new lambda.Code.fromAsset method.